### PR TITLE
여행 출발 위치를 저장하는 백엔드 코드 추가

### DIFF
--- a/planner/urls.py
+++ b/planner/urls.py
@@ -1,13 +1,14 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from .views import TravelPlanViewSet, DestinationViewSet
+from .views import TravelPlanViewSet, DestinationViewSet, OriginViewSet
 
 app_name = "planner"
 
 router = DefaultRouter()
 router.register("travelplan", TravelPlanViewSet, basename="travelplan")
 router.register("destination", DestinationViewSet, basename="destination")
+router.register("origin", OriginViewSet, basename="origin")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/planner/views.py
+++ b/planner/views.py
@@ -167,7 +167,7 @@ class OriginViewSet(
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        queryset = Location.objects.filter(plan__user=self.request.user, type="origin")
+        queryset = Location.objects.filter(type="origin")
         plan_id = self.request.query_params.get("plan")
         if plan_id:
             queryset = queryset.filter(plan__id=plan_id)

--- a/planner/views.py
+++ b/planner/views.py
@@ -142,3 +142,60 @@ class DestinationViewSet(
         output.pop("plan", None)
         status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response(output, status=status_code)
+
+
+class OriginViewSet(
+    viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateModelMixin
+):
+    """
+    - GET  /api/plan/origin/         → 현재 사용자 소유 TravelPlan에 연결된
+                                        type='origin'인 Location 목록 조회
+    - POST /api/plan/origin/         → Origin upsert
+       • 요청바디:
+         {
+             "plan": "<plan_uuid>",
+             "place_id": "...",
+             "name": "...",
+             "address": "...",
+             "lat": 12.34,
+             "lng": 56.78
+         }
+       • 내부에서 `type="origin"`을 자동 주입 → upsert_location 호출
+    """
+
+    serializer_class = LocationModelSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = Location.objects.filter(plan__user=self.request.user, type="origin")
+        plan_id = self.request.query_params.get("plan")
+        if plan_id:
+            queryset = queryset.filter(plan__id=plan_id)
+        return queryset
+
+    def create(self, request, *args, **kwargs):
+        user = request.user
+        data = request.data.copy()
+
+        plan_id = data.get("plan")
+        if not plan_id:
+            return Response(
+                {"plan": "이 필드는 반드시 필요합니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        travel_plan = get_object_or_404(TravelPlan, pk=plan_id, user=user)
+
+        data["type"] = "origin"
+
+        serializer = self.get_serializer(data=data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+
+        location, created = upsert_location(
+            user=user, plan_id=travel_plan.id, validated_data=serializer.validated_data
+        )
+
+        output = self.get_serializer(location).data
+        output.pop("plan", None)
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        return Response(output, status=status_code)


### PR DESCRIPTION
<!--
  🚀 통합 PR 템플릿
  하나의 기능 단위로 PR 생성 시 사용하세요.
  해당되지 않는 항목은 삭제한 뒤 PR 을 생성해주세요.
-->

## 📌 요약 (Summary)

<!-- PR의 목적과 주요 변경 사항을 간단히 서술하세요 -->

여행 출발지를 입력받고 저장하는 view 와 url 을 추가했습니다.
Location 모델의 type 을 origin 으로 하여 출발지를 저장하며, 기존의 여행지 Location 코드를 작성하며 함께 작성했던 serializer 와 service 레이어 메소드를 공유합니다. 

---

## 📂 WBS 기반 작업 분류

- **대분류**:
  1. 여행 피드 / 2. 여행지 정보 제공 / 3. 여행 계획 생성 / 4. 사용자 인증/관리 / etc.  
     3. 여행 계획 생성
- **상세 코드**:  
  PLAN_ORIGIN_SELECT

---

## ✏️ 작업 내용 (Details)

### 1. 백엔드

- **View**

  ```text
  OriginViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateModelMixin)
  ```

- **Model**

  ```text
  Location
  : 기존의 Location 모델을 유지, type 을 origin 으로 하는 인스턴스의 관리를 담당하는 뷰 작성
  ```

- **URL**

  ```text
  URL: `/api/plan/origin`
  ```

- **외부 API**

  ```text
  외부 API: 
  ```

- **DB 마이그레이션**

  ```text

  ```

---

---

## 🔗 관련 이슈 (Related Issue)

Closes #13 

---
