### PR TITLE
여행지와 출발지의 공항 탐색 기능 추가

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "crispy_bootstrap5",
     "django_bootstrap5",
     "planner",
+    "flight",
 ]
 
 REST_FRAMEWORK = {

--- a/config/settings.py
+++ b/config/settings.py
@@ -22,6 +22,8 @@ env = environ.Env()
 environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
 
 GOOGLE_PLACES_API_KEY = env("GOOGLE_PLACES_API_KEY")
+AMADEUS_CLIENT_ID = env("AMADEUS_CLIENT_ID")
+AMADEUS_CLIENT_SECRET = env("AMADEUS_CLIENT_SECRET")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/config/urls.py
+++ b/config/urls.py
@@ -4,5 +4,6 @@ from django.urls import path, include
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/plan/", include("planner.urls", namespace="planner_api")),
+    path("api/flight/", include("flight.urls", namespace="flight")),
     path("plan/", include("planner.template_urls", namespace="planner")),
 ]

--- a/flight/admin.py
+++ b/flight/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/flight/apps.py
+++ b/flight/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class FlightConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "flight"

--- a/flight/models.py
+++ b/flight/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/flight/services.py
+++ b/flight/services.py
@@ -12,15 +12,15 @@ logger = logging.getLogger(__name__)
 def get_nearest_airport(lat, lon):
     """
     주어진 위경도(lat, lon)로부터 가장 가까운 공항 정보를 반환합니다.
-    반환값 예시: {"iata": "ICN", "name": "Incheon International Airport"}
-    실패 시 None을 반환합니다.
+    api test 환경에서는 다음 국가에 대해서만 조회 가능합니다.
+    United States, Spain, United Kingdom, Germany and India
     """
     try:
         response = amadeus.reference_data.locations.airports.get(
             latitude=lat,
             longitude=lon,
-            radius=5000,
-            page_limit=1,
+            radius=500,
+            sort="distance",
         )
         data = response.data
         if data and len(data) > 0:
@@ -30,7 +30,7 @@ def get_nearest_airport(lat, lon):
                 "name": airport.get("name", ""),
             }
     except ResponseError as e:
-        logger.error("Amadeus API Error in get_nearest_airport: %s", e)
+        logger.error("Amadeus Error in get_nearest_airport: %s", e)
     except Exception as e:
         logger.exception("Unexpected error in get_nearest_airport: %s", e)
     return None

--- a/flight/services.py
+++ b/flight/services.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from amadeus import Client, ResponseError
+import logging
+
+amadeus = Client(
+    client_id=settings.AMADEUS_CLIENT_ID, client_secret=settings.AMADEUS_CLIENT_SECRET
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_nearest_airport(lat, lon):
+    """
+    주어진 위경도(lat, lon)로부터 가장 가까운 공항 정보를 반환합니다.
+    반환값 예시: {"iata": "ICN", "name": "Incheon International Airport"}
+    실패 시 None을 반환합니다.
+    """
+    try:
+        response = amadeus.reference_data.locations.airports.get(
+            latitude=lat,
+            longitude=lon,
+            radius=5000,
+            page_limit=1,
+        )
+        data = response.data
+        if data and len(data) > 0:
+            airport = data[0]
+            return {
+                "iata": airport.get("iataCode"),
+                "name": airport.get("name", ""),
+            }
+    except ResponseError as e:
+        logger.error("Amadeus API Error in get_nearest_airport: %s", e)
+    except Exception as e:
+        logger.exception("Unexpected error in get_nearest_airport: %s", e)
+    return None

--- a/flight/tests.py
+++ b/flight/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/flight/urls.py
+++ b/flight/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+from .views import AirportNearOriginAPIView, AirportNearDestAPIView
+
+urlpatterns = [
+    # 출발지 근처 공항 조회
+    path(
+        "airports/from/",
+        AirportNearOriginAPIView.as_view(),
+        name="api_flight_airport_near_origin",
+    ),
+    # 도착지 근처 공항 조회
+    path(
+        "airports/to/",
+        AirportNearDestAPIView.as_view(),
+        name="api_flight_airport_near_dest",
+    ),
+]

--- a/flight/urls.py
+++ b/flight/urls.py
@@ -1,14 +1,14 @@
 from django.urls import path
 from .views import AirportNearOriginAPIView, AirportNearDestAPIView
 
+app_name = "flight"
+
 urlpatterns = [
-    # 출발지 근처 공항 조회
     path(
         "airports/from/",
         AirportNearOriginAPIView.as_view(),
         name="api_flight_airport_near_origin",
     ),
-    # 도착지 근처 공항 조회
     path(
         "airports/to/",
         AirportNearDestAPIView.as_view(),

--- a/flight/views.py
+++ b/flight/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/flight/views.py
+++ b/flight/views.py
@@ -12,11 +12,11 @@ class AirportNearOriginAPIView(APIView):
     def get(self, request):
         plan_id = request.query_params.get("plan_id")
         plan = get_object_or_404(TravelPlan, id=plan_id, user=request.user)
-        origin_loc = plan.location_set.filter(type="origin").first()
+        origin_loc = plan.locations.filter(type="origin").first()
         if not origin_loc:
             return Response({"error": "Origin location not found."}, status=404)
 
-        result = get_nearest_airport(origin_loc.latitude, origin_loc.longitude)
+        result = get_nearest_airport(origin_loc.lat, origin_loc.lng)
         if not result:
             return Response({"error": "Nearest airport not found."}, status=400)
         return Response(result)
@@ -28,7 +28,7 @@ class AirportNearDestAPIView(APIView):
     def get(self, request):
         plan_id = request.query_params.get("plan_id")
         plan = get_object_or_404(TravelPlan, id=plan_id, user=request.user)
-        dest_loc = plan.location_set.filter(type="destination").first()
+        dest_loc = plan.locations.filter(type="destination").first()
         if not dest_loc:
             return Response({"error": "Destination location not found."}, status=404)
 

--- a/flight/views.py
+++ b/flight/views.py
@@ -1,3 +1,38 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django.shortcuts import get_object_or_404
+from planner.models import TravelPlan
+from .services import get_nearest_airport
 
-# Create your views here.
+
+class AirportNearOriginAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        plan_id = request.query_params.get("plan_id")
+        plan = get_object_or_404(TravelPlan, id=plan_id, user=request.user)
+        origin_loc = plan.location_set.filter(type="origin").first()
+        if not origin_loc:
+            return Response({"error": "Origin location not found."}, status=404)
+
+        result = get_nearest_airport(origin_loc.latitude, origin_loc.longitude)
+        if not result:
+            return Response({"error": "Nearest airport not found."}, status=400)
+        return Response(result)
+
+
+class AirportNearDestAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        plan_id = request.query_params.get("plan_id")
+        plan = get_object_or_404(TravelPlan, id=plan_id, user=request.user)
+        dest_loc = plan.location_set.filter(type="destination").first()
+        if not dest_loc:
+            return Response({"error": "Destination location not found."}, status=404)
+
+        result = get_nearest_airport(dest_loc.latitude, dest_loc.longitude)
+        if not result:
+            return Response({"error": "Nearest airport not found."}, status=400)
+        return Response(result)

--- a/planner/models.py
+++ b/planner/models.py
@@ -67,14 +67,3 @@ class Location(models.Model):
         null=True,
         help_text="Googleplaces API에서 제공하는 고유 장소 ID",
     )
-
-
-class Airport(models.Model):
-    location = models.OneToOneField(
-        Location, on_delete=models.CASCADE, related_name="airport"
-    )
-    IATA_code = models.CharField(max_length=50)
-    name = models.CharField(max_length=50)
-    lat = models.FloatField(help_text="위도(latitude)")
-    lng = models.FloatField(help_text="경도(longitude)")
-    distance = models.FloatField(help_text="출발/여행지로부터 거리")

--- a/planner/models.py
+++ b/planner/models.py
@@ -67,3 +67,14 @@ class Location(models.Model):
         null=True,
         help_text="Googleplaces API에서 제공하는 고유 장소 ID",
     )
+
+
+class Airport(models.Model):
+    location = models.OneToOneField(
+        Location, on_delete=models.CASCADE, related_name="airport"
+    )
+    IATA_code = models.CharField(max_length=50)
+    name = models.CharField(max_length=50)
+    lat = models.FloatField(help_text="위도(latitude)")
+    lng = models.FloatField(help_text="경도(longitude)")
+    distance = models.FloatField(help_text="출발/여행지로부터 거리")


### PR DESCRIPTION
<!--
  🚀 통합 PR 템플릿
  하나의 기능 단위로 PR 생성 시 사용하세요.
  해당되지 않는 항목은 삭제한 뒤 PR 을 생성해주세요.
-->

## 📌 요약 (Summary)

<!-- PR의 목적과 주요 변경 사항을 간단히 서술하세요 -->

여행지와 출발지의 위치를 기준으로 각각 가장 가까운 공항을 탐색하여 출국 할공편과 귀국 항공편의 공항을 설정할 수 있습니다. 
IATA 코드를 비롯한 전세계 공항을 모두 DB 에 미리 저장해두는 대신에 AMADEUS 의 airport nearest relevant API 를 사용해서 매 요청마다 공항을 탐색하도록 구현했습니다. 

---

## 📂 WBS 기반 작업 분류

- **대분류**:
  1. 여행 피드 / 2. 여행지 정보 제공 / 3. 여행 계획 생성 / 4. 사용자 인증/관리 / etc.  
     예) 3. 여행 계획 생성
- **상세 코드**:  
AIRPORT_NEAR_ORIGIN

---

## ✏️ 작업 내용 (Details)

### 1. 백엔드

- **View**

  ```text
  AirportNearOriginAPIView, AirportNearDestAPIView
  ```

- **Model**

  ```text

  ```

- **URL**

  ```text
  URL: `/api/flight/airports/from/`, `/api/flight/airports/to/`
  ```

- **외부 API**

  ```text
  외부 API: AMADEUS airport nearest relevant API
  ```

- **DB 마이그레이션**

  ```text

  ```

---

## 🔗 관련 이슈 (Related Issue)

Closes #22 
Closes #23 

---
